### PR TITLE
feat: Integrate BunnyCDN for video output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 COPY . .
 
 # Install Python dependencies
-RUN pip install --no-cache-dir --upgrade pip &&     pip install --no-cache-dir torch==2.2.2 torchvision==0.17.2 torchaudio==2.2.2 --index-url https://download.pytorch.org/whl/cu118 &&     pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --upgrade pip &&     pip install --no-cache-dir torch==2.2.2 torchvision==0.17.2 torchaudio==2.2.2 --index-url https://download.pytorch.org/whl/cu118 &&     pip install --no-cache-dir -r requirements.txt &&     pip install --no-cache-dir runpod requests
 
 # Download pre-trained models
 RUN python3 -m pip install "huggingface_hub[cli]" &&     huggingface-cli download EEEELY/DICE-Talk --local-dir checkpoints --exclude "*/.git*" "*/.gitattributes" &&     huggingface-cli download stabilityai/stable-video-diffusion-img2vid-xt --local-dir checkpoints/stable-video-diffusion-img2vid-xt --exclude "*/.git*" "*/.gitattributes" &&     huggingface-cli download openai/whisper-tiny --local-dir checkpoints/whisper-tiny --exclude "*/.git*" "*/.gitattributes"

--- a/runpod_handler.py
+++ b/runpod_handler.py
@@ -1,20 +1,23 @@
 import os
 import runpod
 import tempfile
-import requests
+import requests # Make sure requests is imported
 from dice_talk import DICE_Talk
 import uuid
 
-# Initialize the DICE_Talk pipe
-# It's recommended to initialize models outside the handler function
-# to reuse them across multiple requests if the worker stays warm.
-pipe = DICE_Talk(device_id=0) # Assuming GPU device_id 0
+# BunnyCDN Configuration (Consider moving AccessKey to environment variables for security in a real scenario)
+BUNNYCDN_STORAGE_HOSTNAME = "storage.bunnycdn.com"
+BUNNYCDN_STORAGE_ZONE_NAME = "zockto" # Your storage zone name
+BUNNYCDN_VIDEO_PATH = "video" # The path within your storage zone
+BUNNYCDN_ACCESS_KEY = "17e23633-2a7a-4d29-9450be4d6c8e-e01f-45f4" # Your AccessKey
+BUNNYCDN_PUBLIC_HOSTNAME = "zockto.b-cdn.net" # Your public CDN hostname
+
+pipe = DICE_Talk(device_id=0)
 
 def download_file(url, local_path):
-    """Downloads a file from a URL to a local path."""
     try:
         response = requests.get(url, stream=True)
-        response.raise_for_status()  # Raise an exception for bad status codes
+        response.raise_for_status()
         with open(local_path, 'wb') as f:
             for chunk in response.iter_content(chunk_size=8192):
                 f.write(chunk)
@@ -23,21 +26,50 @@ def download_file(url, local_path):
         print(f"Error downloading {url}: {e}")
         return None
 
+def upload_to_bunnycdn(local_file_path, unique_key):
+    """Uploads a file to BunnyCDN storage and returns the public URL."""
+    file_name = f"{unique_key}.mp4"
+    upload_url = f"https://{BUNNYCDN_STORAGE_HOSTNAME}/{BUNNYCDN_STORAGE_ZONE_NAME}/{BUNNYCDN_VIDEO_PATH}/{file_name}"
+
+    headers = {
+        "AccessKey": BUNNYCDN_ACCESS_KEY,
+        "Content-Type": "application/octet-stream" # Or video/mp4, but octet-stream is common for PUT
+    }
+
+    try:
+        with open(local_file_path, 'rb') as f_data:
+            response = requests.put(upload_url, data=f_data, headers=headers)
+
+        response.raise_for_status() # Will raise an HTTPError if the HTTP request returned an unsuccessful status code
+
+        if response.status_code == 201: # Created
+            public_url = f"https://{BUNNYCDN_PUBLIC_HOSTNAME}/{BUNNYCDN_VIDEO_PATH}/{file_name}"
+            return True, public_url
+        else:
+            error_message = f"BunnyCDN upload failed with status {response.status_code}: {response.text}"
+            print(error_message)
+            return False, error_message
+
+    except requests.exceptions.RequestException as e:
+        error_message = f"Error uploading to BunnyCDN: {e}"
+        print(error_message)
+        return False, error_message
+    except IOError as e:
+        error_message = f"Error reading local file {local_file_path}: {e}"
+        print(error_message)
+        return False, error_message
+
+
 def handler(job):
-    """
-    Handler function for RunPod Serverless.
-    Takes a job input, processes it with DICE_Talk, and returns the output.
-    """
     job_input = job['input']
 
     image_url = job_input.get('image_url')
     audio_url = job_input.get('audio_url')
-    emotion_type = job_input.get('emotion', 'neutral') # Default to neutral if not specified
+    emotion_type = job_input.get('emotion', 'neutral')
 
-    # Optional parameters from demo.py, with defaults
     ref_scale = float(job_input.get('ref_scale', 3.0))
     emo_scale = float(job_input.get('emo_scale', 6.0))
-    crop = bool(job_input.get('crop', False)) # Input should be true or false
+    crop = bool(job_input.get('crop', False))
     seed = job_input.get('seed')
     if seed is not None:
         seed = int(seed)
@@ -45,44 +77,45 @@ def handler(job):
     if not image_url or not audio_url:
         return {"error": "Missing image_url or audio_url in input"}
 
-    # Create temporary files for downloaded inputs and output
-    # Using a temporary directory that cleans up after itself
     with tempfile.TemporaryDirectory() as tmpdir:
-        local_image_path = os.path.join(tmpdir, f"input_image_{uuid.uuid4().hex}.png") # Assume png, or try to infer
-        local_audio_path = os.path.join(tmpdir, f"input_audio_{uuid.uuid4().hex}.wav") # Assume wav, or try to infer
+        # Generate unique names for temporary local files
+        temp_image_filename = f"input_image_{uuid.uuid4().hex}"
+        temp_audio_filename = f"input_audio_{uuid.uuid4().hex}"
+        # Try to get extension from URL or default
+        image_ext = os.path.splitext(image_url)[1] or '.png'
+        audio_ext = os.path.splitext(audio_url)[1] or '.wav'
+
+        local_image_path = os.path.join(tmpdir, f"{temp_image_filename}{image_ext}")
+        local_audio_path = os.path.join(tmpdir, f"{temp_audio_filename}{audio_ext}")
+        # Output video will also be temporary before upload
         local_output_path = os.path.join(tmpdir, f"output_video_{uuid.uuid4().hex}.mp4")
 
-        # Download image and audio
-        print(f"Downloading image from: {image_url}")
+
+        print(f"Downloading image from: {image_url} to {local_image_path}")
         if not download_file(image_url, local_image_path):
             return {"error": f"Failed to download image from {image_url}"}
 
-        print(f"Downloading audio from: {audio_url}")
+        print(f"Downloading audio from: {audio_url} to {local_audio_path}")
         if not download_file(audio_url, local_audio_path):
             return {"error": f"Failed to download audio from {audio_url}"}
 
-        # Determine emotion file path
-        # Ensure this path matches the structure in your Docker image
         emotion_file_name = f"{emotion_type}.npy"
         emotion_path = os.path.join("examples", "emo", emotion_file_name)
 
         if not os.path.exists(emotion_path):
-            # Fallback to neutral if specified emotion file doesn't exist
             print(f"Emotion file {emotion_path} not found. Falling back to neutral.")
             emotion_path = os.path.join("examples", "emo", "neutral.npy")
             if not os.path.exists(emotion_path):
                  return {"error": f"Neutral emotion file not found at {emotion_path}. Critical emotion files missing."}
 
-
         print(f"Processing with DICE-Talk: image='{local_image_path}', audio='{local_audio_path}', emotion='{emotion_path}'")
 
         try:
-            # Preprocessing step (cropping if specified)
             face_info = pipe.preprocess(local_image_path, expand_ratio=0.5)
             print(f"Face info: {face_info}")
 
             processed_image_path = local_image_path
-            if face_info['face_num'] > 0: # Check if face_num is greater than 0, not >=0
+            if face_info['face_num'] > 0:
                 if crop:
                     crop_image_filename = os.path.join(tmpdir, f"input_image_cropped_{uuid.uuid4().hex}.png")
                     pipe.crop_image(local_image_path, crop_image_filename, face_info['crop_bbox'])
@@ -90,63 +123,42 @@ def handler(job):
                     print(f"Cropped image saved to: {processed_image_path}")
             elif face_info['face_num'] == 0:
                 print("No face detected in the image. Proceeding with the original image.")
-            else: # face_num < 0, indicates an error during preprocessing
+            else:
                 return {"error": f"Error during face preprocessing: {face_info.get('error_message', 'Unknown error')}"}
 
-
-            # Main processing
             pipe.process(
                 image_path=processed_image_path,
                 audio_path=local_audio_path,
                 emotion_path=emotion_path,
                 output_path=local_output_path,
-                min_resolution=512, # Default from demo.py
-                inference_steps=25, # Default from demo.py
+                min_resolution=512,
+                inference_steps=25,
                 ref_scale=ref_scale,
                 emo_scale=emo_scale,
                 seed=seed
             )
 
             if os.path.exists(local_output_path):
-                # Upload the video to a bucket or return as a presigned URL
-                # For simplicity here, we'll return the video data as a base64 string
-                # or a URL if using runpod.upload_file (which requires bucket setup)
-
-                # Example: Upload to RunPod's temporary S3 bucket and get a presigned URL
-                # This is generally preferred for larger files.
-                # presigned_url = runpod.upload_file(f"output_{job['id']}.mp4", local_output_path)
-                # return {"video_url": presigned_url}
-
-                # For now, let's assume the video might be small enough to be returned directly
-                # or this part needs to be configured by the user with their S3 bucket.
-                # As a placeholder, we'll indicate success and path.
-                # In a real scenario, you'd upload this file and return the URL.
                 print(f"Output video successfully generated: {local_output_path}")
-                # To return the actual file, you'd need to read and encode it, or use runpod.upload
-                # For testing, we can just return a success message.
-                # For actual use, the user needs to decide how to handle the output file (e.g., upload to S3)
-                # For now, we'll just confirm it was created. RunPod itself might have a way to retrieve it from tmp.
 
-                # Returning the file content directly (might hit size limits for large videos)
-                with open(local_output_path, 'rb') as video_file:
-                    video_data = video_file.read()
+                video_unique_key = str(uuid.uuid4())
+                upload_success, result_or_error = upload_to_bunnycdn(local_output_path, video_unique_key)
 
-                # runpod.serverless.utils.rp_upload.upload_file_to_bucket() can be used if S3 integrated
-                # For now, returning a success message, actual file handling might need more setup
-                # by the user (e.g. setting up an S3 bucket for runpod.upload)
-
-                # The simplest way for a user to test without S3 is to get it from worker logs or have a very small output.
-                # A better approach is to upload it and return a URL.
-                # For now, let's make it try to upload to job-specific output if available.
-                # This is a RunPod feature that allows direct output of files.
-                return {"output_video_path": local_output_path, "message": "Video generated. How to retrieve it depends on RunPod output configuration."}
-
-
+                if upload_success:
+                    public_video_url = result_or_error
+                    print(f"Video uploaded to BunnyCDN: {public_video_url}")
+                    return {"video_url": public_video_url}
+                else:
+                    error_message = result_or_error
+                    print(f"Failed to upload video to BunnyCDN: {error_message}")
+                    return {"error": f"Failed to upload video to BunnyCDN: {error_message}"}
             else:
-                return {"error": "Output video not generated."}
+                return {"error": "Output video not generated by DICE-Talk process."}
         except Exception as e:
-            print(f"Error during DICE-Talk processing: {e}")
-            return {"error": f"Error during DICE-Talk processing: {str(e)}"}
+            print(f"Error during DICE-Talk processing or upload: {e}")
+            # It's good to log the stack trace for debugging
+            import traceback
+            traceback.print_exc()
+            return {"error": f"Error during processing or upload: {str(e)}"}
 
-# Start the RunPod serverless worker
 runpod.serverless.start({"handler": handler})


### PR DESCRIPTION
Updates the RunPod handler to upload generated videos to BunnyCDN and return a public URL.

Changes:
- Modified `runpod_handler.py`:
    - Added a function `upload_to_bunnycdn` to handle PUT requests to BunnyCDN storage, including AccessKey header.
    - The main handler now calls this function after video generation.
    - Returns a public BunnyCDN URL (e.g., https://zockto.b-cdn.net/video/{unique-key}.mp4) on successful upload.
    - Includes BunnyCDN configuration details (storage zone, path, access key, public hostname).
- Updated `Dockerfile`:
    - Explicitly added `requests` to the pip install command to ensure the HTTP client library is available for uploads.

This allows you to store and access the output videos via BunnyCDN.